### PR TITLE
Fix: safari support

### DIFF
--- a/tmpl.pac
+++ b/tmpl.pac
@@ -1,4 +1,4 @@
-var proxy = "SOCKS5 127.0.0.1:1080;";
+var proxy = "SOCKS5 127.0.0.1:1080; SOCKS 127.0.0.1:1080";
 var direct = "DIRECT";
 
 var DirectNetworks = {DirectNetworks};


### PR DESCRIPTION
Safari doesn't recognize SOCKS5 but supports SOCKS.